### PR TITLE
Add example config and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@ with OpenAI, and send a daily email summary. This repository contains sample
 modules for integrating with Google Calendar, Trello, and Asana, aggregating
 results, summarizing with the OpenAI API, and formatting the output for email
 delivery.
+
+## Configuration
+
+1. Copy `config.example.yml` to `config.yml` in the project root.
+2. Edit the copied file and fill in your service credentials, API keys and
+   preferred delivery time.
+
+API keys such as `openai_api_key`, `trello_api_key`, and `asana_access_token`
+should be kept secret. Store them in environment variables or a secrets manager
+and reference them in `config.yml` if desired.

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,0 +1,30 @@
+# Example configuration for Daily TODO
+# Copy this file to `config.yml` and update the values
+
+# Path to Google service account credentials JSON
+google_credentials_path: "path/to/credentials.json"
+
+# Trello API credentials
+trello_api_key: "YOUR_TRELLO_API_KEY"
+trello_token: "YOUR_TRELLO_TOKEN"
+
+# Asana personal access token
+asana_access_token: "YOUR_ASANA_TOKEN"
+
+# OpenAI API key used for summarization and transcription
+openai_api_key: "YOUR_OPENAI_API_KEY"
+
+# Time of day to deliver the summary email (24h format)
+delivery_time: "08:00"
+
+# Email settings for outgoing messages
+email:
+  smtp_server: "smtp.example.com"
+  smtp_port: 587
+  username: "user@example.com"
+  password: "securepassword"
+  recipient: "recipient@example.com"
+
+# Additional arbitrary settings can be placed here
+other_settings:
+  sample: "value"


### PR DESCRIPTION
## Summary
- add `config.example.yml` showing all `UserConfig` fields
- document how to copy and customize the config in the README
- advise keeping API keys in environment variables or secrets manager

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684212803b74832cbea7ecca7f4a3ed7