### PR TITLE
Add email dispatch to daily summary

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,12 @@
+email:
+  smtp_server: smtp.example.com
+  smtp_port: 587
+  username: your_username
+  password: your_password
+  recipient: recipient@example.com
+
+google_credentials_path: path/to/credentials.json
+trello_api_key: your_trello_key
+trello_token: your_trello_token
+asana_access_token: your_asana_token
+openai_api_key: your_openai_key

--- a/daily_todo/main.py
+++ b/daily_todo/main.py
@@ -9,6 +9,9 @@ from .integrations.asana import get_tasks_due_today as asana_tasks
 from .aggregator import aggregate
 from .llm import summarize
 from .email_formatter import format_email
+from .email_dispatch import send_email
+
+DEFAULT_SUBJECT = "Daily Summary"
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +29,11 @@ def run_daily_summary(cfg: config.UserConfig):
     summary = summarize(merged, cfg.openai_api_key)
     email_body = format_email(summary, merged)
     logger.info("Generated email:\n%s", email_body)
-    # TODO: send email using cfg.email settings
+    subject = DEFAULT_SUBJECT
+    try:
+        send_email(cfg.email, subject, email_body)
+    except Exception:
+        logger.exception("Error sending email")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- deliver the daily summary email in `run_daily_summary`
- add default email subject and call `send_email`
- provide sample configuration

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68420f238efc832c8433ddc8b3dbb23d