### PR TITLE
Improve aggregator deduplication

### DIFF
--- a/daily_todo/aggregator.py
+++ b/daily_todo/aggregator.py
@@ -1,13 +1,55 @@
 from __future__ import annotations
 
-from typing import Iterable, List, Dict
+from typing import Iterable, List, Dict, Set
 
 
 def aggregate(items: Iterable[Iterable[Dict]]) -> List[Dict]:
-    """Merge lists of tasks/events into a single list."""
-    merged = []
+    """Merge lists of tasks/events into a single list.
+
+    The function keeps track of IDs seen per source so duplicate records from
+    the same provider are ignored.  Items that share the same title and due date
+    across different sources are merged and their sources combined for
+    traceability.  The returned list is sorted by the ``due`` field when
+    available.
+    """
+
+    merged: List[Dict] = []
+    seen_ids: Dict[str, Set[str]] = {}
+
     for collection in items:
-        merged.extend(collection)
-    # sort by due date/time if available
+        for item in collection:
+            source = item.get("source")
+            item_id = item.get("id")
+
+            if source and item_id:
+                ids = seen_ids.setdefault(source, set())
+                if item_id in ids:
+                    # Skip exact duplicates from the same source
+                    continue
+                ids.add(item_id)
+
+            title = item.get("title")
+            due = item.get("due")
+
+            existing = None
+            for current in merged:
+                if current.get("title") == title and current.get("due") == due:
+                    existing = current
+                    break
+
+            if existing is not None:
+                if source:
+                    existing_source = existing.get("source")
+                    if existing_source is None:
+                        existing["source"] = source
+                    elif isinstance(existing_source, list):
+                        if source not in existing_source:
+                            existing_source.append(source)
+                    elif existing_source != source:
+                        existing["source"] = [existing_source, source]
+                continue
+
+            merged.append(dict(item))
+
     merged.sort(key=lambda x: x.get("due") or "")
     return merged

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,0 +1,22 @@
+from daily_todo.aggregator import aggregate
+
+
+def test_merge_and_deduplicate():
+    data = [
+        [
+            {"id": "1", "title": "Task A", "due": "2021-01-01", "source": "trello"},
+            {"id": "2", "title": "Task B", "due": "2021-01-02", "source": "trello"},
+        ],
+        [
+            {"id": "1", "title": "Task A", "due": "2021-01-01", "source": "trello"},
+        ],
+        [
+            {"id": "3", "title": "Task A", "due": "2021-01-01", "source": "asana"},
+        ],
+    ]
+    result = aggregate(data)
+    assert len(result) == 2
+    # result sorted by due so first item is Task A
+    assert result[0]["title"] == "Task A"
+    assert sorted(result[0]["source"] if isinstance(result[0]["source"], list) else [result[0]["source"]]) == ["asana", "trello"]
+


### PR DESCRIPTION
## Summary
- merge duplicate items by title and due date
- track seen IDs to prevent duplication
- keep source information when merging
- add tests for aggregator deduplication

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420f2b5fb8832c8cabe66e03f093d7