### PR TITLE
Add scheduler runner script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,17 @@ with OpenAI, and send a daily email summary. This repository contains sample
 modules for integrating with Google Calendar, Trello, and Asana, aggregating
 results, summarizing with the OpenAI API, and formatting the output for email
 delivery.
+
+## Running the scheduler
+
+1. Install dependencies with `pip install -r requirements.txt`.
+2. Create a `config.yml` file containing your credentials and desired
+   `delivery_time`.
+3. Start the scheduler:
+
+   ```bash
+   python run_scheduler.py
+   ```
+
+The process loads your configuration, schedules `run_daily_summary` for the
+specified delivery time, and keeps running to execute pending jobs each day.

--- a/run_scheduler.py
+++ b/run_scheduler.py
@@ -1,0 +1,17 @@
+import logging
+
+from daily_todo import config, scheduler
+from daily_todo.main import run_daily_summary
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+def main() -> None:
+    cfg = config.load_config()
+    scheduler.schedule_daily(cfg.delivery_time, lambda: run_daily_summary(cfg))
+    scheduler.run_pending()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_scheduler.py` to load config and run the scheduler loop
- document how to start the scheduler in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420f315cfc832c843f605e6726e8d1