### PR TITLE
Add pytest suite and mock external services

### DIFF
--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,0 +1,10 @@
+import pytest
+
+from daily_todo.aggregator import aggregate
+
+
+def test_aggregate_sorting():
+    item1 = {'title': 'First', 'due': '2023-01-02'}
+    item2 = {'title': 'Second', 'due': '2023-01-01'}
+    result = aggregate([[item1], [item2]])
+    assert result == [item2, item1]

--- a/tests/test_email_formatter.py
+++ b/tests/test_email_formatter.py
@@ -1,0 +1,16 @@
+from daily_todo.email_formatter import highlight_keywords, format_email
+
+
+def test_highlight_keywords():
+    text = 'urgent meeting today'
+    assert highlight_keywords(text) == '**urgent** **meeting** **today**'
+
+
+def test_format_email():
+    summary = 'An urgent task'
+    items = [
+        {'title': 'Task', 'due': '2023-01-01'}
+    ]
+    body = format_email(summary, items)
+    assert 'Task (2023-01-01)' in body
+    assert '**urgent**' in body

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,0 +1,93 @@
+import sys
+import datetime as dt
+from types import SimpleNamespace
+
+import pytest
+
+# Provide minimal stubs for google modules so imports succeed without the
+# real dependencies installed.
+sys.modules['google'] = SimpleNamespace()
+
+class DummyCreds:
+    @classmethod
+    def from_service_account_file(cls, path, scopes=None):
+        return cls()
+
+sys.modules['google.oauth2'] = SimpleNamespace(service_account=SimpleNamespace(Credentials=DummyCreds))
+sys.modules['google.oauth2.service_account'] = SimpleNamespace(Credentials=DummyCreds)
+sys.modules['googleapiclient'] = SimpleNamespace()
+sys.modules['googleapiclient.discovery'] = SimpleNamespace(build=lambda *a, **k: None)
+sys.modules['requests'] = SimpleNamespace(get=lambda *a, **k: None)
+
+from daily_todo.integrations import google_calendar, trello, asana
+
+
+class DummyResponse:
+    def __init__(self, json_data):
+        self._json = json_data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._json
+
+
+def test_trello(monkeypatch):
+    expected = [{
+        'id': '1', 'name': 'card', 'due': dt.date.today().isoformat()
+    }]
+
+    def fake_get(url, params=None, timeout=None):
+        return DummyResponse(expected)
+
+    monkeypatch.setattr(trello.requests, 'get', fake_get, raising=False)
+
+    tasks = trello.get_tasks_due_today('key', 'token')
+    assert tasks[0]['title'] == 'card'
+
+
+def test_asana(monkeypatch):
+    expected = {
+        'data': [
+            {'gid': '1', 'name': 'task', 'due_on': dt.date.today().isoformat()}
+        ]
+    }
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        return DummyResponse(expected)
+
+    monkeypatch.setattr(asana.requests, 'get', fake_get, raising=False)
+
+    tasks = asana.get_tasks_due_today('token')
+    assert tasks[0]['title'] == 'task'
+
+
+def test_google_calendar(monkeypatch):
+    events = [{
+        'id': '1', 'summary': 'meet',
+        'start': {'dateTime': '2023-01-01T00:00:00Z'}
+    }]
+
+    class DummyEvents:
+        def list(self, **kwargs):
+            return self
+
+        def execute(self):
+            return {'items': events}
+
+    class DummyService:
+        def events(self):
+            return DummyEvents()
+
+    def fake_build(*args, **kwargs):
+        return DummyService()
+
+    def fake_creds(path, scopes=None):
+        return object()
+
+    monkeypatch.setattr(google_calendar, 'build', fake_build, raising=False)
+    monkeypatch.setattr(google_calendar.Credentials, 'from_service_account_file', fake_creds, raising=False)
+
+    result = google_calendar.get_today_events('creds.json')
+    assert result[0]['title'] == 'meet'

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,33 @@
+import sys
+from types import SimpleNamespace
+
+# Provide a minimal openai stub so the module can be imported without the
+# actual dependency installed.
+sys.modules['openai'] = SimpleNamespace(ChatCompletion=SimpleNamespace(create=None))
+
+from daily_todo.llm import summarize
+
+
+def test_summarize(monkeypatch):
+    called = {}
+
+    def fake_create(**kwargs):
+        called['kwargs'] = kwargs
+        return {
+            'choices': [
+                {'message': {'content': 'result summary'}}
+            ]
+        }
+
+    monkeypatch.setattr('openai.ChatCompletion.create', fake_create)
+
+    data = [
+        {'title': 'Task1', 'due': '2023-01-01'},
+        {'title': 'Task2', 'due': '2023-01-02'}
+    ]
+
+    result = summarize(data, api_key='key')
+
+    assert result == 'result summary'
+    assert called['kwargs']['model'] == 'gpt-3.5-turbo'
+    assert any('Task1' in m['content'] for m in called['kwargs']['messages'])


### PR DESCRIPTION
## Summary
- add pytest tests for aggregator, llm, email formatter and integrations
- mock external APIs (Google Calendar, Trello, Asana, OpenAI)

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420f392f78832c8ca0aad4cfa5ca39