### PR TITLE
Add email dispatch to daily summary

### DIFF
--- a/daily_todo/main.py
+++ b/daily_todo/main.py
@@ -9,6 +9,7 @@ from .integrations.asana import get_tasks_due_today as asana_tasks
 from .aggregator import aggregate
 from .llm import summarize
 from .email_formatter import format_email
+from .email_dispatch import send_email
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,10 @@ def run_daily_summary(cfg: config.UserConfig):
     summary = summarize(merged, cfg.openai_api_key)
     email_body = format_email(summary, merged)
     logger.info("Generated email:\n%s", email_body)
-    # TODO: send email using cfg.email settings
+    try:
+        send_email(cfg.email, "Daily Summary", email_body)
+    except Exception as exc:
+        logger.error("Error sending email: %s", exc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- send daily summary emails from main script
- log any email delivery issues

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684210ad7d50832c9b35472f126c57e3